### PR TITLE
Fix NeuronSpiking kernel wrappers

### DIFF
--- a/include/NeuroGen/cuda/NeuronSpikingKernels.cuh
+++ b/include/NeuroGen/cuda/NeuronSpikingKernels.cuh
@@ -20,7 +20,8 @@ struct GPUSpikeEvent;
 __global__ void resetSpikeFlags(GPUNeuronState* neurons, int num_neurons);
 
 __global__ void countSpikesKernel(const GPUNeuronState* neurons,
-                                 int* spike_count, int num_neurons);
+                                 int* spike_count, int num_neurons,
+                                 float current_time);
 
 /**
  * CUDA kernel to update the spiking state of neurons
@@ -29,7 +30,8 @@ __global__ void countSpikesKernel(const GPUNeuronState* neurons,
  * @param num_neurons Total number of neurons
  */
 __global__ void updateNeuronSpikes(GPUNeuronState* neurons,
-                                  float threshold, int num_neurons);
+                                  int num_neurons, float current_time,
+                                  float dt);
 
 /**
  * CUDA kernel to detect spikes and record spike events
@@ -41,7 +43,10 @@ __global__ void updateNeuronSpikes(GPUNeuronState* neurons,
  * @param current_time Current simulation time
  */
 __global__ void detectSpikes(const GPUNeuronState* neurons,
-                            GPUSpikeEvent* spikes, float threshold,
-                            int* spike_count, int num_neurons, float current_time);
+                            GPUSpikeEvent* spikes,
+                            int* spike_count, int num_neurons,
+                            float current_time,
+                            int* module_assignments,
+                            int max_spike_events);
 
 #endif // NEURON_SPIKING_KERNELS_CUH

--- a/src/cuda/NeuronSpikingKernelWrappers.cu
+++ b/src/cuda/NeuronSpikingKernelWrappers.cu
@@ -7,6 +7,9 @@
 #include "NeuroGen/cuda/GPUNeuralStructures.h"
 #include "NeuroGen/cuda/NeuronModelConstants.h"
 #include <cuda_runtime.h>
+#include <cstdio>
+#include <vector>
+#include <chrono>
 
 // ============================================================================
 // EXTERNAL LINKAGE WRAPPER FUNCTIONS
@@ -18,17 +21,21 @@
  * This wrapper ensures proper linkage for the NetworkCUDA class while
  * maintaining the biologically accurate spike detection implementation.
  */
-extern "C" void updateNeuronSpikes(GPUNeuronState* neurons, float threshold, int num_neurons) {
+extern "C" void launchUpdateNeuronSpikesHost(GPUNeuronState* neurons,
+                                             int num_neurons,
+                                             float current_time,
+                                             float dt) {
     dim3 block(256);
     dim3 grid((num_neurons + block.x - 1) / block.x);
-    
+
     // Launch the actual CUDA kernel with proper parameters
-    updateNeuronSpikes<<<grid, block>>>(neurons, threshold, num_neurons);
+    updateNeuronSpikes<<<grid, block>>>(neurons, num_neurons, current_time, dt);
     
     // Check for kernel launch errors
     cudaError_t error = cudaGetLastError();
     if (error != cudaSuccess) {
-        printf("CUDA Error in updateNeuronSpikes: %s\n", cudaGetErrorString(error));
+        fprintf(stderr, "CUDA Error in launchUpdateNeuronSpikesHost: %s\n",
+                cudaGetErrorString(error));
     }
     
     // Synchronize to ensure completion
@@ -41,17 +48,21 @@ extern "C" void updateNeuronSpikes(GPUNeuronState* neurons, float threshold, int
  * This wrapper provides the exact function signature expected by NetworkCUDA
  * while leveraging our advanced spike counting implementation.
  */
-extern "C" void countSpikesKernel(const GPUNeuronState* neurons, int* spike_count, int num_neurons) {
+extern "C" void launchCountSpikes(const GPUNeuronState* neurons,
+                                   int* spike_count,
+                                   int num_neurons,
+                                   float current_time) {
     dim3 block(256);
     dim3 grid((num_neurons + block.x - 1) / block.x);
-    
+
     // Launch the actual CUDA kernel
-    countSpikesKernel<<<grid, block>>>(neurons, spike_count, num_neurons);
+    countSpikesKernel<<<grid, block>>>(neurons, spike_count, num_neurons, current_time);
     
     // Check for kernel launch errors
     cudaError_t error = cudaGetLastError();
     if (error != cudaSuccess) {
-        printf("CUDA Error in countSpikesKernel: %s\n", cudaGetErrorString(error));
+        fprintf(stderr, "CUDA Error in launchCountSpikes: %s\n",
+                cudaGetErrorString(error));
     }
     
     // Synchronize to ensure completion
@@ -65,8 +76,8 @@ extern "C" void countSpikesKernel(const GPUNeuronState* neurons, int* spike_coun
  * enabling the breakthrough neural architecture to handle complex spike dynamics
  * with optimal performance.
  */
-extern "C" void processNeuralSpikes(GPUNeuronState* neurons, int* spike_count, 
-                                   float threshold, float current_time, 
+extern "C" void processNeuralSpikes(GPUNeuronState* neurons, int* spike_count,
+                                   float current_time,
                                    int num_neurons, float dt) {
     if (!neurons || !spike_count || num_neurons <= 0) {
         printf("Error: Invalid parameters for processNeuralSpikes\n");
@@ -102,7 +113,7 @@ extern "C" void processNeuralSpikes(GPUNeuronState* neurons, int* spike_count,
  */
 extern "C" void processModularSpikes(GPUNeuronState* neurons, int* spike_count,
                                     int* module_assignments, float* attention_weights,
-                                    float threshold, float current_time,
+                                    float current_time,
                                     int num_neurons, int num_modules, float dt) {
     if (!neurons || !spike_count || num_neurons <= 0) {
         return;
@@ -122,8 +133,8 @@ extern "C" void processModularSpikes(GPUNeuronState* neurons, int* spike_count,
     }
     
     // Standard spike detection and counting
-    updateNeuronSpikes<<<grid, block>>>(neurons, threshold, num_neurons);
-    countSplikesKernel<<<grid, block>>>(neurons, spike_count, num_neurons, current_time);
+    updateNeuronSpikes<<<grid, block>>>(neurons, num_neurons, current_time, dt);
+    countSpikesKernel<<<grid, block>>>(neurons, spike_count, num_neurons, current_time);
     
     cudaDeviceSynchronize();
 }
@@ -136,41 +147,28 @@ extern "C" void processModularSpikes(GPUNeuronState* neurons, int* spike_count,
  * @brief Legacy compatibility wrapper for older NetworkCUDA interfaces
  */
 extern "C" void launchSpikeDetection(GPUNeuronState* d_neurons, int* d_spike_count,
-                                    int num_neurons, float threshold, float current_time) {
-    processNeuralSpikes(d_neurons, d_spike_count, threshold, current_time, num_neurons, 0.1f);
+                                    int num_neurons, float current_time) {
+    processNeuralSpikes(d_neurons, d_spike_count, current_time, num_neurons, 0.1f);
 }
 
 /**
  * @brief Simplified interface for basic spike counting
  */
-extern "C" int countActiveNeurons(const GPUNeuronState* neurons, int num_neurons, float threshold) {
+extern "C" int countActiveNeurons(const GPUNeuronState* neurons, int num_neurons, float current_time) {
     if (!neurons || num_neurons <= 0) return 0;
     
     int* d_count;
     cudaMalloc(&d_count, sizeof(int));
     cudaMemset(d_count, 0, sizeof(int));
     
-    countSplikesKernel(neurons, d_count, num_neurons);
+    countSpikesKernel<<<(num_neurons + 255)/256, 256>>>(neurons, d_count, num_neurons, current_time);
+    cudaDeviceSynchronize();
     
     int h_count = 0;
     cudaMemcpy(&h_count, d_count, sizeof(int), cudaMemcpyDeviceToHost);
     cudaFree(d_count);
     
     return h_count;
-}
-
-// ============================================================================
-// KERNEL FUNCTION DECLARATIONS FOR PROPER LINKAGE
-// ============================================================================
-
-// Ensure the actual kernel functions are properly declared and linked
-__global__ void updateNeuronSpikes(GPUNeuronState* neurons, float threshold, int num_neurons);
-__global__ void countSplikesKernel(const GPUNeuronState* neurons, int* spike_count, 
-                                   int num_neurons, float current_time);
-__global__ void updateNeuronSpikes(GPUNeuronState* neurons, int num_neurons, 
-                                  float current_time, float dt);
-
-// Advanced modular processing functions
 extern "C" void launchProcessModularInteractions(GPUNeuronState* neurons, int num_neurons,
                                                 int* module_assignments, float* attention_weights,
                                                 float* global_inhibition, float current_time);
@@ -182,7 +180,7 @@ extern "C" void launchProcessModularInteractions(GPUNeuronState* neurons, int nu
 /**
  * @brief Monitor spike processing performance for optimization
  */
-extern "C" float benchmarkSpikeProcessing(GPUNeuronState* neurons, int num_neurons, 
+extern "C" float benchmarkSpikeProcessing(GPUNeuronState* neurons, int num_neurons,
                                          int iterations = 100) {
     if (!neurons || num_neurons <= 0) return 0.0f;
     
@@ -191,7 +189,7 @@ extern "C" float benchmarkSpikeProcessing(GPUNeuronState* neurons, int num_neuro
     
     // Warm up
     for (int i = 0; i < 10; i++) {
-        updateNeuronSpikes(neurons, 30.0f, num_neurons);
+        updateNeuronSpikes<<<(num_neurons + 255)/256, 256>>>(neurons, num_neurons, 0.0f, 1.0f);
     }
     cudaDeviceSynchronize();
     
@@ -199,11 +197,10 @@ extern "C" float benchmarkSpikeProcessing(GPUNeuronState* neurons, int num_neuro
     auto start = std::chrono::high_resolution_clock::now();
     
     for (int i = 0; i < iterations; i++) {
-        updateNeuronSpikes(neurons, 30.0f, num_neurons);
-        countSplikesKernel(neurons, d_spike_count, num_neurons);
+        updateNeuronSpikes<<<(num_neurons + 255)/256, 256>>>(neurons, num_neurons, 0.0f, 1.0f);
+        countSpikesKernel<<<(num_neurons + 255)/256, 256>>>(neurons, d_spike_count, num_neurons, 0.0f);
     }
     cudaDeviceSynchronize();
-    
     auto end = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
     


### PR DESCRIPTION
## Summary
- update `NeuronSpikingKernels.cuh` signatures to match implementation
- overhaul `NeuronSpikingKernelWrappers.cu` wrappers and cleanup

## Testing
- `make` *(fails: `nlohmann/json.hpp` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861f246d1c48320a643399da01ab122