### PR TITLE
Rebuild brain module architecture core

### DIFF
--- a/include/NeuroGen/BrainModuleArchitecture.h
+++ b/include/NeuroGen/BrainModuleArchitecture.h
@@ -1,472 +1,91 @@
 // ============================================================================
-// BRAIN MODULE ARCHITECTURE HEADER - NLP-FOCUSED
+// REIMAGINED BRAIN MODULE ARCHITECTURE
 // File: include/NeuroGen/BrainModuleArchitecture.h
 // ============================================================================
 
 #ifndef BRAIN_MODULE_ARCHITECTURE_H
 #define BRAIN_MODULE_ARCHITECTURE_H
 
-#include <memory>
-#include <vector>
 #include <map>
+#include <memory>
+#include <random>
 #include <string>
-#include <functional>
-#include <mutex>
-#include <atomic>
-#include <chrono>
 #include <unordered_map>
-#include <set>
-#include <queue>
-#include <thread>
-#include <condition_variable>
-
-// NeuroGen Framework Includes
-#include "NeuroGen/NeuralModule.h"
-#include "NeuroGen/EnhancedNeuralModule.h"
-#include "NeuroGen/ModularNeuralNetwork.h"
-#include "NeuroGen/NetworkConfig.h"
-#include "NeuroGen/LearningStateManager.h"
-
-// Forward declarations
-class LearningStateManager;
-class NetworkCUDA;
-class ContinuousLearningAgent;
+#include <vector>
 
 /**
- * @brief Simplified Brain-inspired Architecture for Natural Language Processing
- * 
- * This class implements a streamlined brain-inspired modular architecture
- * specifically designed for natural language processing. It consists of
- * five core modules:
- * 
- * 1. Language Perception Module - reading and tokenization
- * 2. Comprehension Module - semantic integration
- * 3. Reasoning Module - logical inference
- * 4. Output Generation Module - language production
- * 5. Neuromodulation Module - adaptive control
- * 
- * Key Features:
- * - Simplified 5-module architecture optimized for NLP
- * - Inter-module connections form processing pipeline
- * - Neuromodulatory control from central controller
- * - Attention mechanisms for language processing
- * - Independent state saving/loading for each module
- * - Continuous learning through language interaction
+ * @brief BrainModuleArchitecture now models each module as a standalone
+ * cortical column style neural network.  The architecture is intentionally
+ * simple – it focuses on the internal structure of a single module so that
+ * additional modules can later be connected sparsely to form a larger brain.
  */
 class BrainModuleArchitecture : public std::enable_shared_from_this<BrainModuleArchitecture> {
 public:
-    // ========================================================================
-    // CORE CONFIGURATION STRUCTURES
-    // ========================================================================
-    
-    struct ArchitectureConfig {
-        int max_modules = 5;                    // Fixed to 5 for NLP architecture
-        bool enable_inter_module_learning = true;
-        bool enable_attention_mechanism = true;
-        bool enable_memory_consolidation = true;
-        bool enable_structural_plasticity = false; // Simplified for NLP
-        float global_inhibition_strength = 0.1f;
-        float attention_update_rate = 0.01f;
-        float memory_consolidation_rate = 0.005f;
-        std::string architecture_type = "nlp_focused";
+    struct CorticalColumnLayer {
+        size_t input_size = 0;
+        size_t output_size = 0;
+        std::vector<float> weights;
+        std::vector<float> biases;
+        float activation_gain = 1.0f;
+
+        std::vector<float> forward(const std::vector<float>& input) const;
     };
-    
-    struct ModuleConfig {
-        std::string module_name;
-        std::string module_type;
-        int num_neurons = 1024;
-        int input_size = 512;
-        int output_size = 512;
-        float learning_rate = 0.01f;
-        float attention_weight = 0.5f;
-        bool enable_plasticity = true;
-        bool is_excitatory = true;
+
+    struct BrainModule {
+        std::string name;
+        size_t input_size = 0;
+        size_t output_size = 0;
+        std::vector<CorticalColumnLayer> cortical_layers;
+        std::vector<float> last_output;
+
+        std::vector<float> process(const std::vector<float>& input);
     };
-    
-    struct InterModuleConnection {
+
+    struct ModuleConnection {
         std::string source_module;
         std::string target_module;
-        float connection_strength = 0.5f;
-        std::string connection_type = "excitatory"; // excitatory, inhibitory, modulatory
-        bool is_active = true;
-        bool is_plastic = true;
-        float plasticity_rate = 0.001f;
+        float strength = 0.0f;
     };
-    
-    struct InterModuleConnectionState {
-        float current_strength = 0.5f;
-        float baseline_strength = 0.5f;
-        float activity_trace = 0.0f;
-        std::chrono::steady_clock::time_point last_update;
-        bool is_potentiated = false;
-        float efficacy_history = 0.0f;
-    };
-    
-    // ========================================================================
-    // CONSTRUCTION AND INITIALIZATION
-    // ========================================================================
-    
-    /**
-     * @brief Construct NLP-focused brain architecture
-     */
+
     BrainModuleArchitecture();
-    
-    /**
-     * @brief Destructor
-     */
     ~BrainModuleArchitecture();
-    
-    /**
-     * @brief Initialize architecture for NLP processing
-     * @return Success status
-     */
+
     bool initializeForNLP();
-    
-    /**
-     * @brief Initialize with legacy interface (calls initializeForNLP)
-     * @param input_width Ignored in NLP mode
-     * @param input_height Ignored in NLP mode
-     * @return Success status
-     */
     bool initialize(int input_width = 0, int input_height = 0);
-    
-    /**
-     * @brief Shutdown and cleanup architecture
-     */
     void shutdown();
-    
-    // ========================================================================
-    // NLP-SPECIFIC PROCESSING INTERFACE
-    // ========================================================================
-    
-    /**
-     * @brief Process natural language input through the architecture
-     * @param text_input Raw text input to process
-     * @return Map of module names to their output vectors
-     */
-    std::map<std::string, std::vector<float>> processNLPInput(const std::string& text_input);
-    
-    /**
-     * @brief Process tokenized language input with learning
-     * @param tokenized_input Pre-tokenized input vector
-     * @param reward Global reward signal for learning
-     * @return Map of module outputs
-     */
-    std::map<std::string, std::vector<float>> processTokenizedInput(
-        const std::vector<float>& tokenized_input, 
-        float reward = 0.0f);
-    
-    /**
-     * @brief Generate language response from current state
-     * @return Generated response text
-     */
-    std::string generateLanguageResponse();
-    
-    /**
-     * @brief Convert text to neural tokens
-     * @param text Input text
-     * @return Tokenized representation
-     */
-    std::vector<float> tokenizeText(const std::string& text);
-    
-    /**
-     * @brief Apply neuromodulatory control to input
-     * @param input Base input vector
-     * @param control_signals Control signals from central controller
-     * @return Modulated input vector
-     */
-    std::vector<float> applyNeuromodulation(
-        const std::vector<float>& input, 
-        const std::vector<float>& control_signals);
-    
-    // ========================================================================
-    // MODULE MANAGEMENT
-    // ========================================================================
-    
-    /**
-     * @brief Get all module names
-     * @return Vector of module names
-     */
+
+    BrainModule& createBrainModule(const std::string& name,
+                                   size_t input_size,
+                                   size_t output_size,
+                                   size_t column_count,
+                                   size_t column_width);
+
+    bool hasModule(const std::string& name) const;
+    std::shared_ptr<BrainModule> getModule(const std::string& name) const;
+
+    std::vector<float> stimulateModule(const std::string& module_name,
+                                       const std::vector<float>& input);
+
+    std::vector<float> getLastModuleOutput(const std::string& module_name) const;
+
+    std::vector<float> processVisualInput(const std::vector<float>& visual_input);
+
     std::vector<std::string> getModuleNames() const;
-    
-    /**
-     * @brief Get total number of modules
-     * @return Module count
-     */
     size_t getModuleCount() const;
-    
-    /**
-     * @brief Check if module exists
-     * @param module_name Module name to check
-     * @return True if module exists
-     */
-    bool hasModule(const std::string& module_name) const;
-    
-    /**
-     * @brief Get module by name
-     * @param module_name Module name
-     * @return Shared pointer to module (nullptr if not found)
-     */
-    std::shared_ptr<EnhancedNeuralModule> getModule(const std::string& module_name) const;
-    
-    /**
-     * @brief Get module configuration
-     * @param module_name Module name
-     * @return Module configuration
-     */
-    ModuleConfig getModuleConfig(const std::string& module_name) const;
-    
-    /**
-     * @brief Get outputs from specific module
-     * @param module_name Module name
-     * @return Output vector (empty if module not found)
-     */
-    std::vector<float> getModuleOutput(const std::string& module_name) const;
-    
-    // ========================================================================
-    // CONNECTION MANAGEMENT
-    // ========================================================================
-    
-    /**
-     * @brief Create connection between modules
-     * @param source_module Source module name
-     * @param target_module Target module name
-     * @param strength Connection strength
-     * @return Success status
-     */
-    bool createConnection(const std::string& source_module, 
-                         const std::string& target_module, 
-                         float strength);
-    
-    /**
-     * @brief Get all inter-module connections
-     * @return Vector of connection configurations
-     */
-    std::vector<InterModuleConnection> getConnections() const;
-    
-    /**
-     * @brief Check if connection exists
-     * @param source_module Source module name
-     * @param target_module Target module name
-     * @return True if connection exists
-     */
-    bool hasConnection(const std::string& source_module, const std::string& target_module) const;
-    
-    /**
-     * @brief Get connections for a specific module
-     * @param module_name Module name
-     * @param incoming If true, get incoming connections; if false, get outgoing
-     * @return Vector of connections
-     */
-    std::vector<InterModuleConnection> getModuleConnections(
-        const std::string& module_name, bool incoming = true) const;
-    
-    // ========================================================================
-    // ATTENTION AND CONTROL
-    // ========================================================================
-    
-    /**
-     * @brief Update attention weights based on module outputs
-     * @param module_outputs Current module outputs
-     */
-    void updateAttentionWeights(const std::map<std::string, std::vector<float>>& module_outputs);
-    
-    /**
-     * @brief Get current attention weight for module
-     * @param module_name Module name
-     * @return Attention weight (0.0 to 1.0)
-     */
-    float getAttentionWeight(const std::string& module_name) const;
-    
-    /**
-     * @brief Set attention weight for module
-     * @param module_name Module name
-     * @param weight New attention weight
-     */
-    void setAttentionWeight(const std::string& module_name, float weight);
-    
-    /**
-     * @brief Get global context vector
-     * @return Current global context
-     */
-    std::vector<float> getGlobalContext() const;
-    
-    /**
-     * @brief Update global context from processing results
-     * @param new_context Context update vector
-     */
-    void updateGlobalContext(const std::vector<float>& new_context);
-    
-    // ========================================================================
-    // LEARNING AND ADAPTATION
-    // ========================================================================
-    
-    /**
-     * @brief Update all modules with time step and learning
-     * @param dt Time step in seconds
-     * @param global_reward Global reward signal
-     */
-    void update(float dt, float global_reward = 0.0f);
-    
-    /**
-     * @brief Apply learning updates to all modules
-     * @param reward_signal Global reward signal
-     * @param dt Time step
-     */
-    void applyLearningUpdates(float reward_signal, float dt);
-    
-    /**
-     * @brief Get global learning statistics
-     * @return Learning statistics
-     */
-    struct GlobalLearningState {
-        uint64_t total_learning_steps;
-        float cumulative_reward;
-        float average_module_performance;
-        std::chrono::steady_clock::time_point last_update;
-    };
-    
-    GlobalLearningState getGlobalLearningState() const;
-    
-    // ========================================================================
-    // STATE PERSISTENCE
-    // ========================================================================
-    
-    /**
-     * @brief Save architecture state to directory
-     * @param save_directory Directory path for saving
-     * @param checkpoint_name Optional checkpoint name
-     * @return Success status
-     */
-    bool saveLearningState(const std::string& save_directory, 
-                          const std::string& checkpoint_name = "latest");
-    
-    /**
-     * @brief Load architecture state from directory
-     * @param save_directory Directory path for loading
-     * @param checkpoint_name Optional checkpoint name
-     * @return Success status
-     */
-    bool loadLearningState(const std::string& save_directory, 
-                          const std::string& checkpoint_name = "latest");
-    
-    /**
-     * @brief Save individual module state
-     * @param module_name Module name
-     * @param save_directory Directory path
-     * @return Success status
-     */
-    bool saveModuleLearningState(const std::string& module_name, 
-                                const std::string& save_directory);
-    
-    /**
-     * @brief Load individual module state
-     * @param module_name Module name
-     * @param save_directory Directory path
-     * @return Success status
-     */
-    bool loadModuleLearningState(const std::string& module_name, 
-                                const std::string& save_directory);
-    
-    // ========================================================================
-    // CONFIGURATION AND CONTROL
-    // ========================================================================
-    
-    /**
-     * @brief Get architecture configuration
-     * @return Current architecture configuration
-     */
-    ArchitectureConfig getArchitectureConfig() const;
-    
-    /**
-     * @brief Update architecture configuration
-     * @param config New configuration
-     * @return Success status
-     */
-    bool updateArchitectureConfig(const ArchitectureConfig& config);
-    
-    /**
-     * @brief Get neuromodulator levels
-     * @return Map of neuromodulator names to levels
-     */
-    std::map<std::string, float> getNeuromodulatorLevels() const;
+
+    bool createConnection(const std::string& source_module,
+                          const std::string& target_module,
+                          float strength);
+    std::vector<ModuleConnection> getConnections() const;
 
 private:
-    // ========================================================================
-    // INTERNAL STATE
-    // ========================================================================
-    
-    // Core configuration
-    ArchitectureConfig architecture_config_;
-    
-    // Core modular network
-    std::unique_ptr<ModularNeuralNetwork> modular_network_;
-    
-    // Module management (5 modules for NLP)
-    std::map<std::string, std::shared_ptr<EnhancedNeuralModule>> modules_;
-    std::map<std::string, ModuleConfig> module_configs_;
-    std::vector<InterModuleConnection> connections_;
-    
-    // Inter-module connection tracking
-    std::map<std::pair<std::string, std::string>, InterModuleConnectionState> inter_module_connections_;
-    std::map<std::pair<std::string, std::string>, float> connection_usage_history_;
-    
-    // Attention and control
-    std::map<std::string, float> attention_weights_;
-    std::map<std::string, float> attention_history_;
-    std::vector<float> global_context_vector_;
-    float global_inhibition_level_ = 0.1f;
-    
-    // Neuromodulation for language processing
-    float global_dopamine_level_ = 0.2f;        // Higher for language reward
-    float global_acetylcholine_level_ = 0.3f;   // Higher for language attention
-    float global_norepinephrine_level_ = 0.15f;
-    float global_serotonin_level_ = 0.1f;
-    
-    // Learning session information
-    mutable std::mutex learning_state_mutex_;
-    uint64_t global_learning_steps_ = 0;
-    float global_reward_accumulator_ = 0.0f;
-    std::chrono::steady_clock::time_point last_update_time_;
-    std::chrono::steady_clock::time_point creation_time_;
-    
-    // Performance tracking for NLP
-    std::map<std::string, std::vector<float>> module_performance_history_;
-    std::map<std::string, float> module_prediction_errors_;
-    std::map<std::string, float> module_stability_scores_;
-    size_t performance_history_size_ = 1000; // Reduced for NLP focus
-    
-    // External interfaces
-    std::shared_ptr<NetworkCUDA> cuda_network_;
-    std::shared_ptr<LearningStateManager> learning_state_manager_;
-    std::weak_ptr<ContinuousLearningAgent> continuous_learning_agent_;
-    
-    // ========================================================================
-    // INTERNAL NLP METHODS
-    // ========================================================================
-    
-    // Module creation and setup
-    void createNLPModules();
-    void setupNLPConnections();
-    void initializeNLPAttentionSystem();
-    
-    // Processing pipeline
-    void processModulePipeline(const std::vector<float>& input,
-                              std::map<std::string, std::vector<float>>& outputs);
-    
-    // Learning and adaptation
-    void updateNeuromodulatorLevels(float reward, float dt);
-    void updateGlobalAttention(float dt);
-    void consolidateMemoryTraces(float dt);
-    
-    // Utility methods
-    std::vector<float> convertTextToTokens(const std::string& text);
-    std::string convertTokensToText(const std::vector<float>& tokens);
-    float computeModuleActivation(const std::vector<float>& output);
-    
-    // Validation and compatibility
-    std::pair<bool, std::string> validateArchitectureCompatibility(const std::string& loaded_hash);
-    std::string generateArchitectureHash() const;
+    CorticalColumnLayer createLayer(size_t input_size, size_t output_size);
+
+    std::unordered_map<std::string, std::shared_ptr<BrainModule>> modules_;
+    std::vector<ModuleConnection> connections_;
+
+    bool initialized_ = false;
+    std::mt19937 random_engine_;
 };
 
 #endif // BRAIN_MODULE_ARCHITECTURE_H

--- a/src/BrainModuleArchitecture.cpp
+++ b/src/BrainModuleArchitecture.cpp
@@ -1,424 +1,183 @@
 // ============================================================================
-// SIMPLIFIED BRAIN MODULE ARCHITECTURE FOR NLP - FIXED
+// REIMAGINED BRAIN MODULE ARCHITECTURE IMPLEMENTATION
 // File: src/BrainModuleArchitecture.cpp
 // ============================================================================
 
 #include "NeuroGen/BrainModuleArchitecture.h"
-#include "NeuroGen/EnhancedNeuralModule.h"
-#include "NeuroGen/ModularNeuralNetwork.h"
-#include "NeuroGen/LearningStateManager.h"
-#include "NeuroGen/cuda/NetworkCUDA.cuh"
-#include <iostream>
-#include <fstream>
-#include <sstream>
+
 #include <algorithm>
-#include <chrono>
-#include <numeric>
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <stdexcept>
 
-// ============================================================================
-// CONSTRUCTOR AND INITIALIZATION - FIXED
-// ============================================================================
-
-BrainModuleArchitecture::BrainModuleArchitecture() 
-    : last_update_time_(std::chrono::steady_clock::now()),  // FIXED: Correct order
-      creation_time_(std::chrono::steady_clock::now()) {   // FIXED: Correct order
-    
-    // Initialize simplified NLP architecture configuration
-    architecture_config_.max_modules = 5; // Only 5 modules for NLP
-    architecture_config_.enable_inter_module_learning = true;
-    architecture_config_.enable_attention_mechanism = true;
-    architecture_config_.enable_memory_consolidation = true;
-    architecture_config_.enable_structural_plasticity = false; // Simplified for NLP
-    architecture_config_.global_inhibition_strength = 0.1f;
-    architecture_config_.attention_update_rate = 0.01f;
-    architecture_config_.memory_consolidation_rate = 0.005f;
-    
-    // Initialize neuromodulator levels for language processing
-    global_dopamine_level_ = 0.2f;      // Higher for language reward
-    global_acetylcholine_level_ = 0.3f; // Higher for attention in language
-    global_norepinephrine_level_ = 0.15f;
-    global_serotonin_level_ = 0.1f;
-    
-    std::cout << "🧠 Simplified Brain Module Architecture created for NLP processing" << std::endl;
+namespace {
+float safeRandomRange(size_t fan_in) {
+    if (fan_in == 0) {
+        return 1.0f;
+    }
+    return 1.0f / std::sqrt(static_cast<float>(fan_in));
 }
+} // namespace
+
+// ============================================================================
+// CorticalColumnLayer
+// ============================================================================
+
+std::vector<float> BrainModuleArchitecture::CorticalColumnLayer::forward(
+    const std::vector<float>& input) const {
+    if (input.size() != input_size) {
+        throw std::runtime_error("CorticalColumnLayer received mismatched input size");
+    }
+
+    std::vector<float> output(output_size, 0.0f);
+    for (size_t row = 0; row < output_size; ++row) {
+        float sum = biases[row];
+        const size_t row_offset = row * input_size;
+        for (size_t col = 0; col < input_size; ++col) {
+            sum += weights[row_offset + col] * input[col];
+        }
+        output[row] = std::tanh(sum * activation_gain);
+    }
+    return output;
+}
+
+// ============================================================================
+// BrainModule
+// ============================================================================
+
+std::vector<float> BrainModuleArchitecture::BrainModule::process(
+    const std::vector<float>& input) {
+    if (cortical_layers.empty()) {
+        return {};
+    }
+
+    std::vector<float> activation = input;
+    for (const auto& layer : cortical_layers) {
+        activation = layer.forward(activation);
+    }
+
+    last_output = activation;
+    return last_output;
+}
+
+// ============================================================================
+// BrainModuleArchitecture core
+// ============================================================================
+
+BrainModuleArchitecture::BrainModuleArchitecture()
+    : random_engine_(std::random_device{}()) {}
 
 BrainModuleArchitecture::~BrainModuleArchitecture() {
     shutdown();
 }
 
-bool BrainModuleArchitecture::initialize(int input_width, int input_height) {
-    // Standard initialization (kept for compatibility)
-    static_cast<void>(input_width);  // Suppress unused parameter warning
-    static_cast<void>(input_height); // Suppress unused parameter warning
-    return initializeForNLP();
-}
-
 bool BrainModuleArchitecture::initializeForNLP() {
-    std::lock_guard<std::mutex> lock(learning_state_mutex_);
-    
-    std::cout << "🔧 Initializing Brain Module Architecture for NLP processing..." << std::endl;
-    
-    try {
-        // Create simplified modular network for NLP
-        modular_network_ = std::make_unique<ModularNeuralNetwork>();
-        
-        // Initialize learning state manager with proper parameters - FIXED
-        learning_state_manager_ = std::make_shared<LearningStateManager>(
-            shared_from_this(), "nlp_learning_state");
-        
-        // Create the five core NLP modules
-        createNLPModules();
-        
-        // Set up inter-module connections
-        setupNLPConnections();
-        
-        // Initialize attention system for language processing
-        initializeNLPAttentionSystem();
-        
-        // Initialize context vector for language understanding
-        global_context_vector_.resize(512, 0.0f);
-
-        // Setup CUDA network for biologically inspired processing
-        NetworkCUDA::CUDAConfig cuda_cfg;
-        cuda_network_ = std::make_shared<NetworkCUDA>(cuda_cfg);
-
-        size_t total_neurons = 0;
-        for (const auto& [name, cfg] : module_configs_) {
-            total_neurons += cfg.num_neurons;
-        }
-
-        NetworkConfig net_cfg;
-        net_cfg.num_neurons = static_cast<int>(total_neurons);
-        auto [success, err] = cuda_network_->initialize(net_cfg);
-        if (!success) {
-            std::cerr << "❌ Failed to initialize CUDA network: " << err << std::endl;
-        } else {
-            cuda_network_->setBrainArchitecture(shared_from_this());
-            cuda_network_->setLearningStateManager(learning_state_manager_);
-        }
-
-        std::cout << "✅ Brain Module Architecture initialized successfully for NLP" << std::endl;
-        std::cout << "📊 Architecture: " << modules_.size() << " modules, "
-                  << connections_.size() << " connections" << std::endl;
-        
-        return true;
-        
-    } catch (const std::exception& e) {
-        std::cerr << "❌ Failed to initialize Brain Module Architecture: " << e.what() << std::endl;
-        return false;
-    }
+    return initialize();
 }
 
-void BrainModuleArchitecture::createNLPModules() {
-    // Module 1: Neuromodulation Module (adaptive control)
-    ModuleConfig neuromod_config;
-    neuromod_config.module_name = "neuromodulation";
-    neuromod_config.module_type = "adaptive_control";
-    neuromod_config.num_neurons = 2048;
-    neuromod_config.input_size = 512;
-    neuromod_config.output_size = 512;
-    neuromod_config.learning_rate = 0.005f;
-    neuromod_config.attention_weight = 1.0f;
-    neuromod_config.enable_plasticity = true;
-    
-    NetworkConfig neuromod_net_config;
-    neuromod_net_config.num_neurons = neuromod_config.num_neurons;
-    neuromod_net_config.input_size = neuromod_config.input_size;
-    neuromod_net_config.output_size = neuromod_config.output_size;
-    
-    auto neuromod_module = std::make_shared<EnhancedNeuralModule>(
-        neuromod_config.module_name, neuromod_net_config);
-    neuromod_module->initialize();
+bool BrainModuleArchitecture::initialize(int input_width, int input_height) {
+    static_cast<void>(input_width);
+    static_cast<void>(input_height);
 
-    modules_["neuromodulation"] = neuromod_module;
-    module_configs_["neuromodulation"] = neuromod_config;
-    
-    // Module 2: Language Perception Module
-    ModuleConfig perception_config;
-    perception_config.module_name = "language_perception";
-    perception_config.module_type = "tokenization";
-    perception_config.num_neurons = 1024;
-    perception_config.input_size = 1024; // tokenized characters
-    perception_config.output_size = 512;
-    perception_config.learning_rate = 0.01f;
-    perception_config.attention_weight = 0.7f;
-    perception_config.enable_plasticity = true;
-    
-    NetworkConfig perception_net_config;
-    perception_net_config.num_neurons = perception_config.num_neurons;
-    perception_net_config.input_size = perception_config.input_size;
-    perception_net_config.output_size = perception_config.output_size;
-    
-    auto perception_module = std::make_shared<EnhancedNeuralModule>(
-        perception_config.module_name, perception_net_config);
-    perception_module->initialize();
+    shutdown();
+    initialized_ = true;
 
-    modules_["language_perception"] = perception_module;
-    module_configs_["language_perception"] = perception_config;
-    
-    // Module 3: Comprehension Module
-    ModuleConfig comprehension_config;
-    comprehension_config.module_name = "comprehension";
-    comprehension_config.module_type = "semantic_integration";
-    comprehension_config.num_neurons = 4096; // complex language understanding
-    comprehension_config.input_size = 512;
-    comprehension_config.output_size = 1024;
-    comprehension_config.learning_rate = 0.008f;
-    comprehension_config.attention_weight = 0.9f;
-    comprehension_config.enable_plasticity = true;
-    
-    NetworkConfig comprehension_net_config;
-    comprehension_net_config.num_neurons = comprehension_config.num_neurons;
-    comprehension_net_config.input_size = comprehension_config.input_size;
-    comprehension_net_config.output_size = comprehension_config.output_size;
-    
-    auto comprehension_module = std::make_shared<EnhancedNeuralModule>(
-        comprehension_config.module_name, comprehension_net_config);
-    comprehension_module->initialize();
+    // Seed the architecture with a simple module that can be re-used as a
+    // template for experiments.  Additional modules can be created later.
+    createBrainModule("seed_module", 64, 32, 3, 48);
 
-    modules_["comprehension"] = comprehension_module;
-    module_configs_["comprehension"] = comprehension_config;
-    
-    // Module 4: Reasoning Module
-    ModuleConfig reasoning_config;
-    reasoning_config.module_name = "reasoning";
-    reasoning_config.module_type = "logical_reasoning";
-    reasoning_config.num_neurons = 2048;
-    reasoning_config.input_size = 1024;
-    reasoning_config.output_size = 512;
-    reasoning_config.learning_rate = 0.006f;
-    reasoning_config.attention_weight = 0.8f;
-    reasoning_config.enable_plasticity = true;
-    
-    NetworkConfig reasoning_net_config;
-    reasoning_net_config.num_neurons = reasoning_config.num_neurons;
-    reasoning_net_config.input_size = reasoning_config.input_size;
-    reasoning_net_config.output_size = reasoning_config.output_size;
-    
-    auto reasoning_module = std::make_shared<EnhancedNeuralModule>(
-        reasoning_config.module_name, reasoning_net_config);
-    reasoning_module->initialize();
-    
-    modules_["reasoning"] = reasoning_module;
-    module_configs_["reasoning"] = reasoning_config;
-    
-    // Module 5: Output Generation Module
-    ModuleConfig output_config;
-    output_config.module_name = "output_generation";
-    output_config.module_type = "language_production";
-    output_config.num_neurons = 1024;
-    output_config.input_size = 512;
-    output_config.output_size = 256;
-    output_config.learning_rate = 0.01f;
-    output_config.attention_weight = 0.6f;
-    output_config.enable_plasticity = true;
-    
-    NetworkConfig output_net_config;
-    output_net_config.num_neurons = output_config.num_neurons;
-    output_net_config.input_size = output_config.input_size;
-    output_net_config.output_size = output_config.output_size;
-    
-    auto output_module = std::make_shared<EnhancedNeuralModule>(
-        output_config.module_name, output_net_config);
-    output_module->initialize();
-    
-    modules_["output_generation"] = output_module;
-    module_configs_["output_generation"] = output_config;
-    
-    std::cout << "✅ Created 5 NLP modules: Neuromodulation, Perception, Comprehension, Reasoning, Output" << std::endl;
+    std::cout << "🧠 BrainModuleArchitecture initialized with cortical column modules" << std::endl;
+    return true;
 }
 
-void BrainModuleArchitecture::setupNLPConnections() {
-    // Create forward processing pipeline
+void BrainModuleArchitecture::shutdown() {
+    modules_.clear();
     connections_.clear();
-    
-    // Perception -> Comprehension (primary path)
-    InterModuleConnection percept_to_comp;
-    percept_to_comp.source_module = "language_perception";
-    percept_to_comp.target_module = "comprehension";
-    percept_to_comp.connection_strength = 0.8f;
-    percept_to_comp.connection_type = "excitatory";
-    percept_to_comp.is_active = true;
-    connections_.push_back(percept_to_comp);
-    
-    // Comprehension -> Reasoning (reasoning path)
-    InterModuleConnection comp_to_reason;
-    comp_to_reason.source_module = "comprehension";
-    comp_to_reason.target_module = "reasoning";
-    comp_to_reason.connection_strength = 0.7f;
-    comp_to_reason.connection_type = "excitatory";
-    comp_to_reason.is_active = true;
-    connections_.push_back(comp_to_reason);
-    
-    // Reasoning -> Output (output path)
-    InterModuleConnection reason_to_output;
-    reason_to_output.source_module = "reasoning";
-    reason_to_output.target_module = "output_generation";
-    reason_to_output.connection_strength = 0.9f;
-    reason_to_output.connection_type = "excitatory";
-    reason_to_output.is_active = true;
-    connections_.push_back(reason_to_output);
-    
-    // Central Controller connections (neuromodulatory)
-    std::vector<std::string> target_modules = {
-        "language_perception", "comprehension", "reasoning", "output_generation"
-    };
-    
-    for (const auto& target : target_modules) {
-        InterModuleConnection control_conn;
-        control_conn.source_module = "neuromodulation";
-        control_conn.target_module = target;
-        control_conn.connection_strength = 0.5f;
-        control_conn.connection_type = "modulatory";
-        control_conn.is_active = true;
-        connections_.push_back(control_conn);
-    }
-    
-    // Feedback connections
-    InterModuleConnection reason_feedback;
-    reason_feedback.source_module = "reasoning";
-    reason_feedback.target_module = "comprehension";
-    reason_feedback.connection_strength = 0.3f;
-    reason_feedback.connection_type = "inhibitory";
-    reason_feedback.is_active = true;
-    connections_.push_back(reason_feedback);
-    
-    InterModuleConnection output_feedback;
-    output_feedback.source_module = "output_generation";
-    output_feedback.target_module = "neuromodulation";
-    output_feedback.connection_strength = 0.5f;
-    output_feedback.connection_type = "excitatory";
-    output_feedback.is_active = true;
-    connections_.push_back(output_feedback);
-    
-    std::cout << "✅ Established " << connections_.size() << " inter-module connections for NLP pipeline" << std::endl;
+    initialized_ = false;
 }
 
-void BrainModuleArchitecture::initializeNLPAttentionSystem() {
-    // Initialize attention weights for NLP modules
-    attention_weights_["neuromodulation"] = 1.0f;
-    attention_weights_["language_perception"] = 0.7f;
-    attention_weights_["comprehension"] = 0.9f;
-    attention_weights_["reasoning"] = 0.8f;
-    attention_weights_["output_generation"] = 0.6f;
-    
-    // Initialize attention history
-    for (const auto& [module_name, _] : modules_) {
-        attention_history_[module_name] = attention_weights_[module_name];
+BrainModuleArchitecture::BrainModule& BrainModuleArchitecture::createBrainModule(
+    const std::string& name,
+    size_t input_size,
+    size_t output_size,
+    size_t column_count,
+    size_t column_width) {
+    if (name.empty()) {
+        throw std::invalid_argument("Module name cannot be empty");
     }
-    
-    std::cout << "✅ NLP attention system initialized" << std::endl;
+    if (column_count == 0) {
+        column_count = 1;
+    }
+
+    auto module = std::make_shared<BrainModule>();
+    module->name = name;
+    module->input_size = input_size;
+    module->output_size = output_size;
+
+    size_t prev_size = input_size;
+    for (size_t layer_index = 0; layer_index < column_count; ++layer_index) {
+        size_t layer_output = (layer_index == column_count - 1) ? output_size : column_width;
+        module->cortical_layers.push_back(createLayer(prev_size, layer_output));
+        prev_size = layer_output;
+    }
+
+    modules_[name] = module;
+    return *module;
 }
 
-// ============================================================================
-// CORE PROCESSING INTERFACE
-// ============================================================================
-
-std::map<std::string, std::vector<float>> BrainModuleArchitecture::processNLPInput(
-    const std::string& text_input) {
-    
-    std::map<std::string, std::vector<float>> module_outputs;
-    
-    // Tokenize input for neural processing
-    std::vector<float> tokenized_input = tokenizeText(text_input);
-    
-    // STEP 1: Perception module processes tokenized text
-    if (modules_.count("language_perception")) {
-        auto percept_output = modules_["language_perception"]->process(tokenized_input);
-        module_outputs["language_perception"] = percept_output;
-
-        // STEP 2: Neuromodulation module provides control signals
-        if (modules_.count("neuromodulation")) {
-            auto control_output = modules_["neuromodulation"]->process(percept_output);
-            module_outputs["neuromodulation"] = control_output;
-
-            // Apply neuromodulation to comprehension
-            auto modulated = applyNeuromodulation(percept_output, control_output);
-
-            // STEP 3: Comprehension module
-            if (modules_.count("comprehension")) {
-                auto comp_output = modules_["comprehension"]->process(modulated);
-                module_outputs["comprehension"] = comp_output;
-
-                // STEP 4: Reasoning module
-                if (modules_.count("reasoning")) {
-                    auto reason_output = modules_["reasoning"]->process(comp_output);
-                    module_outputs["reasoning"] = reason_output;
-
-                    // STEP 5: Output generation
-                    if (modules_.count("output_generation")) {
-                        auto final_output = modules_["output_generation"]->process(reason_output);
-                        module_outputs["output_generation"] = final_output;
-                    }
-                }
-            }
-        }
-    }
-    
-    // Update attention weights based on processing results
-    updateAttentionWeights(module_outputs);
-    
-    return module_outputs;
+bool BrainModuleArchitecture::hasModule(const std::string& name) const {
+    return modules_.count(name) > 0;
 }
 
-std::vector<float> BrainModuleArchitecture::tokenizeText(const std::string& text) {
-    std::vector<float> tokens(1024, 0.0f);
-    
-    // Simple character-level tokenization
-    for (size_t i = 0; i < text.length() && i < 512; ++i) {
-        tokens[i] = static_cast<float>(text[i]) / 255.0f;
+std::shared_ptr<BrainModuleArchitecture::BrainModule> BrainModuleArchitecture::getModule(
+    const std::string& name) const {
+    auto it = modules_.find(name);
+    if (it != modules_.end()) {
+        return it->second;
     }
-    
-    // Add positional encoding
-    for (size_t i = 0; i < text.length() && i < 512; ++i) {
-        tokens[i + 512] = static_cast<float>(i) / 512.0f;
-    }
-    
-    return tokens;
+    return nullptr;
 }
 
-std::vector<float> BrainModuleArchitecture::applyNeuromodulation(
-    const std::vector<float>& input, 
-    const std::vector<float>& control_signals) {
-    
-    std::vector<float> modulated(input.size());
-    
-    for (size_t i = 0; i < input.size(); ++i) {
-        float control_weight = control_signals.size() > i ? 
-            control_signals[i] : 0.5f;
-        
-        // Apply neuromodulatory scaling
-        modulated[i] = input[i] * (0.5f + 0.5f * std::tanh(control_weight));
+std::vector<float> BrainModuleArchitecture::stimulateModule(
+    const std::string& module_name,
+    const std::vector<float>& input) {
+    auto module = getModule(module_name);
+    if (!module) {
+        throw std::runtime_error("Requested module does not exist: " + module_name);
     }
-    
-    return modulated;
+    if (input.size() != module->input_size) {
+        throw std::runtime_error("Input size does not match module expectations");
+    }
+    return module->process(input);
 }
 
-void BrainModuleArchitecture::updateAttentionWeights(
-    const std::map<std::string, std::vector<float>>& module_outputs) {
-    
-    // Update attention based on module activation levels
-    for (const auto& [module_name, output] : module_outputs) {
-        if (attention_weights_.count(module_name)) {
-            float avg_activation = std::accumulate(output.begin(), output.end(), 0.0f) / output.size();
-            
-            // Gradually adjust attention weight based on activation
-            float target_weight = 0.1f + 0.9f * std::tanh(avg_activation);
-            attention_weights_[module_name] = 
-                0.95f * attention_weights_[module_name] + 0.05f * target_weight;
-        }
+std::vector<float> BrainModuleArchitecture::getLastModuleOutput(
+    const std::string& module_name) const {
+    auto module = getModule(module_name);
+    if (!module) {
+        return {};
     }
+    return module->last_output;
 }
 
-// ============================================================================
-// MODULE MANAGEMENT
-// ============================================================================
+std::vector<float> BrainModuleArchitecture::processVisualInput(
+    const std::vector<float>& visual_input) {
+    auto existing = getModule("visual_cortex");
+    if (!existing || existing->input_size != visual_input.size()) {
+        size_t reduced = std::max<size_t>(visual_input.size() / 4, 64);
+        createBrainModule("visual_cortex", visual_input.size(), reduced, 3, reduced);
+    }
+    return stimulateModule("visual_cortex", visual_input);
+}
 
 std::vector<std::string> BrainModuleArchitecture::getModuleNames() const {
     std::vector<std::string> names;
+    names.reserve(modules_.size());
     for (const auto& [name, _] : modules_) {
         names.push_back(name);
     }
+    std::sort(names.begin(), names.end());
     return names;
 }
 
@@ -426,323 +185,37 @@ size_t BrainModuleArchitecture::getModuleCount() const {
     return modules_.size();
 }
 
-bool BrainModuleArchitecture::hasModule(const std::string& module_name) const {
-    return modules_.count(module_name) > 0;
-}
-
-std::shared_ptr<EnhancedNeuralModule> BrainModuleArchitecture::getModule(
-    const std::string& module_name) const {
-    auto it = modules_.find(module_name);
-    return (it != modules_.end()) ? it->second : nullptr;
-}
-
-BrainModuleArchitecture::ModuleConfig BrainModuleArchitecture::getModuleConfig(
-    const std::string& module_name) const {
-    auto it = module_configs_.find(module_name);
-    return (it != module_configs_.end()) ? it->second : ModuleConfig{};
-}
-
-std::vector<float> BrainModuleArchitecture::getModuleOutput(const std::string& module_name) const {
-    auto it = modules_.find(module_name);
-    if (it != modules_.end() && it->second) {
-        return it->second->process(std::vector<float>(it->second->get_name().length(), 0.1f));
-    }
-    return std::vector<float>();
-}
-
-// ============================================================================
-// CONNECTION MANAGEMENT - FIXED
-// ============================================================================
-
-bool BrainModuleArchitecture::createConnection(
-    const std::string& source_module, 
-    const std::string& target_module, 
-    float strength) {
-    
+bool BrainModuleArchitecture::createConnection(const std::string& source_module,
+                                               const std::string& target_module,
+                                               float strength) {
     if (!hasModule(source_module) || !hasModule(target_module)) {
-        std::cerr << "❌ Cannot create connection: module not found" << std::endl;
         return false;
     }
-    
-    InterModuleConnection connection;
-    connection.source_module = source_module;
-    connection.target_module = target_module;
-    connection.connection_strength = strength;
-    connection.connection_type = "excitatory";
-    connection.is_active = true;
-    
+    ModuleConnection connection{source_module, target_module, strength};
     connections_.push_back(connection);
-    
-    std::cout << "✅ Created connection: " << source_module 
-              << " -> " << target_module << " (strength: " << strength << ")" << std::endl;
-    
     return true;
 }
 
-std::vector<BrainModuleArchitecture::InterModuleConnection> BrainModuleArchitecture::getConnections() const {
-    return connections_;  // FIXED: Return correct type
+std::vector<BrainModuleArchitecture::ModuleConnection> BrainModuleArchitecture::getConnections() const {
+    return connections_;
 }
 
-bool BrainModuleArchitecture::hasConnection(
-    const std::string& source_module, 
-    const std::string& target_module) const {
-    
-    return std::any_of(connections_.begin(), connections_.end(),
-        [&](const InterModuleConnection& conn) {
-            return conn.source_module == source_module && 
-                   conn.target_module == target_module;
-        });
-}
+BrainModuleArchitecture::CorticalColumnLayer BrainModuleArchitecture::createLayer(
+    size_t input_size,
+    size_t output_size) {
+    CorticalColumnLayer layer;
+    layer.input_size = input_size;
+    layer.output_size = output_size;
+    layer.weights.resize(input_size * output_size);
+    layer.biases.resize(output_size);
 
-std::vector<BrainModuleArchitecture::InterModuleConnection> BrainModuleArchitecture::getModuleConnections(
-    const std::string& module_name, bool incoming) const {
-    
-    std::vector<InterModuleConnection> result;
-    
-    for (const auto& conn : connections_) {
-        if (incoming && conn.target_module == module_name) {
-            result.push_back(conn);
-        } else if (!incoming && conn.source_module == module_name) {
-            result.push_back(conn);
-        }
+    std::uniform_real_distribution<float> dist(-safeRandomRange(input_size), safeRandomRange(input_size));
+    for (auto& weight : layer.weights) {
+        weight = dist(random_engine_);
     }
-    
-    return result;
-}
-
-// ============================================================================
-// ATTENTION AND CONTROL
-// ============================================================================
-
-float BrainModuleArchitecture::getAttentionWeight(const std::string& module_name) const {
-    auto it = attention_weights_.find(module_name);
-    return (it != attention_weights_.end()) ? it->second : 0.5f;
-}
-
-void BrainModuleArchitecture::setAttentionWeight(const std::string& module_name, float weight) {
-    attention_weights_[module_name] = std::max(0.0f, std::min(1.0f, weight));
-}
-
-std::vector<float> BrainModuleArchitecture::getGlobalContext() const {
-    return global_context_vector_;
-}
-
-void BrainModuleArchitecture::updateGlobalContext(const std::vector<float>& new_context) {
-    if (new_context.size() == global_context_vector_.size()) {
-        global_context_vector_ = new_context;
+    for (auto& bias : layer.biases) {
+        bias = dist(random_engine_);
     }
-}
 
-std::map<std::string, float> BrainModuleArchitecture::getNeuromodulatorLevels() const {
-    std::map<std::string, float> levels;
-    levels["dopamine"] = global_dopamine_level_;
-    levels["acetylcholine"] = global_acetylcholine_level_;
-    levels["norepinephrine"] = global_norepinephrine_level_;
-    levels["serotonin"] = global_serotonin_level_;
-    return levels;
-}
-
-// ============================================================================
-// UPDATE AND LEARNING
-// ============================================================================
-
-void BrainModuleArchitecture::update(float dt, float global_reward) {
-    std::lock_guard<std::mutex> lock(learning_state_mutex_);
-    
-    // Update global learning steps
-    global_learning_steps_++;
-    global_reward_accumulator_ += global_reward;
-    
-    // Update neuromodulator levels based on reward
-    updateNeuromodulatorLevels(global_reward, dt);
-    
-    // Update all modules
-    for (auto& [name, module] : modules_) {
-        if (module) {
-            std::vector<float> empty_input;
-            module->update(dt, empty_input, global_reward);
-        }
-    }
-    
-    // Update attention system
-    updateGlobalAttention(dt);
-    
-    last_update_time_ = std::chrono::steady_clock::now();
-}
-
-void BrainModuleArchitecture::applyLearningUpdates(float reward_signal, float dt) {
-    // Apply learning updates to all modules
-    for (auto& [name, module] : modules_) {
-        if (module) {
-            std::vector<float> empty_input;
-            module->update(dt, empty_input, reward_signal);
-        }
-    }
-}
-
-BrainModuleArchitecture::GlobalLearningState BrainModuleArchitecture::getGlobalLearningState() const {
-    std::lock_guard<std::mutex> lock(learning_state_mutex_);
-    
-    GlobalLearningState state;
-    state.total_learning_steps = global_learning_steps_;
-    state.cumulative_reward = global_reward_accumulator_;
-    state.average_module_performance = 0.5f; // Placeholder
-    state.last_update = last_update_time_;
-    
-    return state;
-}
-
-void BrainModuleArchitecture::updateNeuromodulatorLevels(float reward, float dt) {
-    // Update dopamine based on reward prediction error
-    float dopamine_target = 0.1f + 0.4f * std::tanh(reward);
-    global_dopamine_level_ = 0.95f * global_dopamine_level_ + 0.05f * dopamine_target;
-    
-    // Update acetylcholine for attention
-    float attention_demand = std::accumulate(attention_weights_.begin(), attention_weights_.end(), 0.0f,
-        [](float sum, const auto& pair) { return sum + pair.second; }) / attention_weights_.size();
-    global_acetylcholine_level_ = 0.98f * global_acetylcholine_level_ + 0.02f * attention_demand;
-    
-    // Maintain norepinephrine and serotonin levels
-    global_norepinephrine_level_ = std::max(0.1f, global_norepinephrine_level_ * 0.999f);
-    global_serotonin_level_ = std::max(0.05f, global_serotonin_level_ * 0.999f);
-    
-    static_cast<void>(dt); // Suppress unused parameter warning
-}
-
-void BrainModuleArchitecture::updateGlobalAttention(float dt) {
-    // Update attention weights with biological dynamics
-    for (auto& [module_name, weight] : attention_weights_) {
-        // Apply attention decay
-        weight *= (1.0f - architecture_config_.attention_update_rate * dt);
-        
-        // Maintain minimum attention
-        weight = std::max(0.1f, weight);
-        
-        // Update history
-        attention_history_[module_name] = 0.9f * attention_history_[module_name] + 0.1f * weight;
-    }
-}
-
-// ============================================================================
-// STATE PERSISTENCE
-// ============================================================================
-
-bool BrainModuleArchitecture::saveLearningState(const std::string& save_directory, 
-                                               const std::string& checkpoint_name) {
-    try {
-        // Create directory if it doesn't exist
-        std::filesystem::create_directories(save_directory);
-        
-        // Save basic state information
-        std::ofstream state_file(save_directory + "/" + checkpoint_name + "_brain_state.txt");
-        if (state_file.is_open()) {
-            state_file << "learning_steps: " << global_learning_steps_ << std::endl;
-            state_file << "reward_accumulator: " << global_reward_accumulator_ << std::endl;
-            state_file << "module_count: " << modules_.size() << std::endl;
-            state_file << "connection_count: " << connections_.size() << std::endl;
-            state_file.close();
-        }
-        
-        std::cout << "💾 Brain architecture state saved to: " << save_directory << std::endl;
-        return true;
-    } catch (const std::exception& e) {
-        std::cerr << "❌ Failed to save brain architecture state: " << e.what() << std::endl;
-        return false;
-    }
-}
-
-bool BrainModuleArchitecture::loadLearningState(const std::string& save_directory, 
-                                               const std::string& checkpoint_name) {
-    try {
-        std::ifstream state_file(save_directory + "/" + checkpoint_name + "_brain_state.txt");
-        if (state_file.is_open()) {
-            std::string line;
-            while (std::getline(state_file, line)) {
-                // Parse basic state information
-                if (line.find("learning_steps:") != std::string::npos) {
-                    global_learning_steps_ = std::stoull(line.substr(line.find(":") + 1));
-                } else if (line.find("reward_accumulator:") != std::string::npos) {
-                    global_reward_accumulator_ = std::stof(line.substr(line.find(":") + 1));
-                }
-            }
-            state_file.close();
-        }
-        
-        std::cout << "📂 Brain architecture state loaded from: " << save_directory << std::endl;
-        return true;
-    } catch (const std::exception& e) {
-        std::cerr << "❌ Failed to load brain architecture state: " << e.what() << std::endl;
-        return false;
-    }
-}
-
-bool BrainModuleArchitecture::saveModuleLearningState(const std::string& module_name, 
-                                                     const std::string& save_directory) {
-    // Simple module state saving
-    try {
-        std::ofstream module_file(save_directory + "/" + module_name + "_module.state");
-        if (module_file.is_open()) {
-            module_file << "module_name: " << module_name << std::endl;
-            module_file << "timestamp: " << std::chrono::duration_cast<std::chrono::seconds>(
-                std::chrono::steady_clock::now().time_since_epoch()).count() << std::endl;
-            module_file.close();
-        }
-        return true;
-    } catch (const std::exception& e) {
-        std::cerr << "❌ Failed to save module state for " << module_name << ": " << e.what() << std::endl;
-        return false;
-    }
-}
-
-bool BrainModuleArchitecture::loadModuleLearningState(const std::string& module_name, 
-                                                     const std::string& save_directory) {
-    // Simple module state loading
-    try {
-        std::ifstream module_file(save_directory + "/" + module_name + "_module.state");
-        if (module_file.is_open()) {
-            std::string line;
-            while (std::getline(module_file, line)) {
-                // Parse module state information
-                // Add actual state loading logic here
-            }
-            module_file.close();
-        }
-        return true;
-    } catch (const std::exception& e) {
-        std::cerr << "❌ Failed to load module state for " << module_name << ": " << e.what() << std::endl;
-        return false;
-    }
-}
-
-// ============================================================================
-// CONFIGURATION
-// ============================================================================
-
-BrainModuleArchitecture::ArchitectureConfig BrainModuleArchitecture::getArchitectureConfig() const {
-    return architecture_config_;
-}
-
-bool BrainModuleArchitecture::updateArchitectureConfig(const ArchitectureConfig& config) {
-    architecture_config_ = config;
-    return true;
-}
-
-// ============================================================================
-// SHUTDOWN
-// ============================================================================
-
-void BrainModuleArchitecture::shutdown() {
-    std::lock_guard<std::mutex> lock(learning_state_mutex_);
-    
-    modules_.clear();
-    module_configs_.clear();
-    connections_.clear();
-    attention_weights_.clear();
-    attention_history_.clear();
-    
-    if (learning_state_manager_) {
-        learning_state_manager_.reset();
-    }
-    
-    std::cout << "🔌 Brain Module Architecture shutdown complete" << std::endl;
+    return layer;
 }


### PR DESCRIPTION
## Summary
- replace the previous NLP-specific brain architecture with a simpler cortical-column-based design where each module is its own neural network
- add APIs for creating/stimulating modules, tracking their outputs, and wiring sparse connections while keeping compatibility helpers such as `initializeForNLP`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916835810188320968c66b32de81696)